### PR TITLE
Added compatibility for OAS without any security.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,8 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 [[package]]
 name = "openapiv3-extended"
 version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82df51e430235c0819e054c3030a974bd7a92cff47455186a9590b87e6292fd9"
 dependencies = [
  "anyhow",
  "http",

--- a/libninja/src/rust/client.rs
+++ b/libninja/src/rust/client.rs
@@ -231,7 +231,7 @@ pub fn impl_Client_without_security(mir_spec: &hir::MirSpec, spec: &OpenAPI, opt
     let new_fn = quote! {
         pub fn new(url: &str) -> Self {
             let client = httpclient::Client::new()
-            .base_url(url);
+                .base_url(url);
             Self {
                 client
             }
@@ -260,7 +260,7 @@ pub fn impl_Client_with_security(mir_spec: &hir::MirSpec, spec: &OpenAPI, opt: &
     let new_fn = quote! {
         pub fn new(url: &str, authentication: #auth_struct_name) -> Self {
             let client = httpclient::Client::new()
-            .base_url(url);
+                .base_url(url);
             Self {
                 client,
                 authentication,


### PR DESCRIPTION
While trying to generate a project using PaperMC's OAS (https://api.papermc.io/openapi), which is notably a OAS without the security fields, I've noticed that it generated the struct and constructors with an Authentication struct that wasn't generated for obvious reasons.

This pull request aims to fix this issue. 

Tested on PaperMC's OAS, and it outputs a functional library.

What has been modified: entrypoint struct generation, entrypoint impl, and entrypoint from_env impl. 

(2nd commit was for stylistic change, forgot 2 tabs lol, you could probably just squash it or whatever)